### PR TITLE
Add minimal static blog generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# Endo-s-Blog
-I will share personal thoughts and insights on this platform
+# Endo's Blog
+
+This repository contains a minimal static blog generator written in Python.
+Posts are written in Markdown and placed in the `posts/` directory.
+Running `build.py` converts them into HTML files inside the `dist/` directory.
+
+## Requirements
+
+- Python 3.7+
+- The `markdown` package (`pip install markdown`)
+
+## Usage
+
+1. Add new Markdown files to the `posts/` directory. Each file should start
+   with a top-level heading that will be used as the post title.
+2. Run the build script:
+
+```bash
+python3 build.py
+```
+
+3. Open `dist/index.html` in your browser to view the site.
+
+Feel free to customize the HTML template under `templates/base.html` and
+extend the generator to suit your needs.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,31 @@
+import os
+import markdown
+from pathlib import Path
+
+template_path = Path('templates/base.html')
+output_dir = Path('dist')
+posts_dir = Path('posts')
+
+output_dir.mkdir(exist_ok=True)
+
+# Load template
+with template_path.open('r') as f:
+    base_tpl = f.read()
+
+index_entries = []
+
+for md_file in posts_dir.glob('*.md'):
+    with md_file.open('r') as f:
+        text = f.read()
+    html_content = markdown.markdown(text)
+    # Title is first heading
+    title = text.splitlines()[0].lstrip('# ').strip()
+    content = base_tpl.replace('{{ title }}', title).replace('{{ content }}', html_content)
+    outfile = output_dir / (md_file.stem + '.html')
+    outfile.write_text(content)
+    index_entries.append(f'<li><a href="{outfile.name}">{title}</a></li>')
+
+index_content = '<h1>My Blog</h1>\n<ul>' + '\n'.join(index_entries) + '</ul>'
+index_html = base_tpl.replace('{{ title }}', 'Home').replace('{{ content }}', index_content)
+(output_dir / 'index.html').write_text(index_html)
+print('Site built in', output_dir)

--- a/posts/welcome.md
+++ b/posts/welcome.md
@@ -1,0 +1,3 @@
+# Welcome to my blog
+
+This is my first post on this blog. Stay tuned for more updates!

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; padding: 1em; }
+        nav a { margin-right: 1em; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="index.html">Home</a>
+</nav>
+<main>
+{{ content }}
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Python-based static blog generator
- add base HTML template and sample post
- update README with usage instructions

## Testing
- `pip install markdown` *(fails: Cannot connect to proxy)*
- `python3 build.py` *(fails: No module named 'markdown')*

------
https://chatgpt.com/codex/tasks/task_e_6845806c4c908332abf2e17ed1781fb1